### PR TITLE
Add penalty display manager

### DIFF
--- a/src/client/java/btwr/btwr_sl/lib/client/BTWRSLModClient.java
+++ b/src/client/java/btwr/btwr_sl/lib/client/BTWRSLModClient.java
@@ -1,6 +1,9 @@
 package btwr.btwr_sl.lib.client;
 
+import btwr.btwr_sl.lib.gui.PenaltyDisplayManager;
 import net.fabricmc.api.ClientModInitializer;
+import net.minecraft.client.MinecraftClient;
+import net.minecraft.client.Mouse;
 
 public class BTWRSLModClient implements ClientModInitializer
 {

--- a/src/client/java/btwr/btwr_sl/lib/event/EventHUDInitialized.java
+++ b/src/client/java/btwr/btwr_sl/lib/event/EventHUDInitialized.java
@@ -1,0 +1,35 @@
+package btwr.btwr_sl.lib.event;
+
+import btwr.btwr_sl.BTWRSLMod;
+import btwr.btwr_sl.lib.gui.HUDInitializeListener;
+import btwr.btwr_sl.lib.gui.PenaltyDisplayManager;
+import net.minecraft.client.MinecraftClient;
+
+import java.util.ArrayList;
+
+public class EventHUDInitialized {
+    /**
+     * List of HUD initialization listeners
+     */
+    private static ArrayList<HUDInitializeListener> hudListeners = new ArrayList<>();
+
+    /**
+     * Registers a HUD init listener
+     * @param listener Listener to register
+     */
+    public static void register(HUDInitializeListener listener) {
+        BTWRSLMod.LOGGER.info("Registering listeners in {}", listener.getClass().getSimpleName());
+        hudListeners.add(listener);
+    }
+
+    /**
+     * Called from mixin when HUD is initialized
+     */
+    public static void hudInitialized(MinecraftClient client) {
+        for (HUDInitializeListener listener : hudListeners) {
+            BTWRSLMod.LOGGER.info("Initializing penalties in {}", listener.getClass().getSimpleName());
+            listener.init(client, PenaltyDisplayManager.getInstance());
+        }
+
+    }
+}

--- a/src/client/java/btwr/btwr_sl/lib/gui/HUDInitializeListener.java
+++ b/src/client/java/btwr/btwr_sl/lib/gui/HUDInitializeListener.java
@@ -1,0 +1,7 @@
+package btwr.btwr_sl.lib.gui;
+
+import net.minecraft.client.MinecraftClient;
+
+public interface HUDInitializeListener {
+    void init(MinecraftClient client, PenaltyDisplayManager displayManager);
+}

--- a/src/client/java/btwr/btwr_sl/lib/gui/PenaltyDisplayManager.java
+++ b/src/client/java/btwr/btwr_sl/lib/gui/PenaltyDisplayManager.java
@@ -1,0 +1,167 @@
+package btwr.btwr_sl.lib.gui;
+
+import net.minecraft.client.MinecraftClient;
+import net.minecraft.client.font.TextRenderer;
+import net.minecraft.client.gui.DrawContext;
+import net.minecraft.entity.player.PlayerEntity;
+import net.minecraft.text.Text;
+
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
+
+/**
+ * Handles rendering of penalties, and their hierarchy
+ */
+public class PenaltyDisplayManager {
+    /**
+     * Instance of PenaltyDisplayManager
+     */
+    private static final PenaltyDisplayManager INSTANCE = new PenaltyDisplayManager();
+
+    public static final int HEALTH_PRIORITY = 0;
+    public static final int GLOOM_PRIORITY = 1;
+    public static final int HUNGER_PRIORITY = 2;
+    /**
+     * List of current penalties to be rendered
+     */
+    private static HashMap<Integer,Penalty> penalties = new HashMap<>();
+    /**
+     * Indicates if the hunger bar is currently rendered
+     */
+    private static boolean isRenderingFood = false;
+
+    public static PenaltyDisplayManager getInstance() {
+        return INSTANCE;
+    }
+
+    /**
+     * Lambda condition test that determines rendering
+     */
+    @FunctionalInterface
+    public interface PenaltyCondition {
+        boolean test();
+    }
+
+    /**
+     * Lambda string getter that determines text drawn
+     */
+    @FunctionalInterface
+    public interface PenaltyString {
+        String get();
+    }
+
+    static public class Penalty {
+        /**
+         * Determines rendering order, with higher values being closer to the hotbar
+         */
+        protected int priority;
+        /**
+         * String that will be rendered
+         */
+        protected PenaltyString display;
+        /**
+         * Condition that must pass in order for text to render
+         */
+        protected PenaltyCondition condition;
+
+        public Penalty(int priority, PenaltyString display, PenaltyCondition condition) {
+            this.priority = priority;
+            this.display = display;
+            this.condition = condition;
+        }
+
+        public Penalty(int priority, String string, PenaltyCondition condition) {
+            this.priority = priority;
+            this.display = () -> string;
+            this.condition = condition;
+        }
+
+        public Penalty(int priority, PenaltyString display) {
+            this.priority = priority;
+            this.display = display;
+            this.condition = () -> true;
+        }
+
+        public int getPriority() {
+            return this.priority;
+        }
+
+        public String getDisplay() {
+            return this.display.get();
+        }
+    }
+
+    public static void render(DrawContext context, TextRenderer renderer) {
+        PlayerEntity player = MinecraftClient.getInstance().player;
+        renderPenalties(context, renderer, player);
+    }
+
+    /**
+     * Draws penalties (if applicable) onto provided context
+     * @param context DrawContext to draw to
+     * @param renderer TextRenderer to use for drawing text
+     * @param player PlayerEntity to get information from
+     */
+    private static void renderPenalties(DrawContext context, TextRenderer renderer, PlayerEntity player) {
+        // Calculate the position of the hunger bar
+        int hungerBarX = context.getScaledWindowWidth() / 2 + 91;  // Center of the hunger bar
+        int hungerBarY = context.getScaledWindowHeight() - 39; // Hunger bar position vertically
+
+        // Get y position to start drawing penalties
+        int textY = getTextY(player, hungerBarY);
+        int offsetY = 0;
+
+        for (Penalty penalty : penalties.values()) {
+            // Get translated text
+            Text translatedText = Text.translatable(penalty.getDisplay());
+
+            // Right align text to hot-bar
+            int statusX = hungerBarX - renderer.getWidth(translatedText);
+
+            // Render
+            if (penalty.condition.test() && !translatedText.equals(Text.of(""))) {
+                context.drawText(renderer, translatedText, statusX, textY - offsetY, 0xFFFFFFFF, true);
+                offsetY += 10;
+            }
+        }
+
+        // Set render boolean to false in-case of HUD changes at runtime
+        isRenderingFood = false;
+    }
+
+    /**
+     * Calculates proper Y position for HUD elements
+     * @param player PlayerEntity to get information from
+     * @param hungerBarY Y position of the hunger bar
+     * @return Calculated Y position
+     */
+    private static int getTextY(PlayerEntity player, int hungerBarY) {
+        // Get additional context
+        boolean isRenderingAir = player.getAir() != player.getMaxAir();
+        boolean isRenderingArmor = player.getArmor() > 0;
+
+        // Default Y position (above the hunger bar, alternatively above hot-bar)
+        int textY = isRenderingFood ? hungerBarY - 10 : hungerBarY;
+
+        // Adjust the Y position under certain conditions
+        if (
+            (isRenderingAir && isRenderingFood) ||  // Player is underwater and food is rendered
+            (isRenderingArmor && !isRenderingFood)) // Player is wearing armor and food is NOT rendered
+            // Future explicit compatibility checks could be done here
+        {
+            textY -= 10;
+        }
+
+        return textY;
+    }
+
+    public static void setRenderingFood(boolean value) {
+        isRenderingFood = value;
+    }
+
+    public void addPenalty(Penalty penalty) {
+        int index = penalty.getPriority();
+        penalties.put(index, penalty);
+    }
+}

--- a/src/client/java/btwr/btwr_sl/lib/gui/PenaltyDisplayManager.java
+++ b/src/client/java/btwr/btwr_sl/lib/gui/PenaltyDisplayManager.java
@@ -1,14 +1,13 @@
 package btwr.btwr_sl.lib.gui;
 
+import btwr.btwr_sl.BTWRSLMod;
 import net.minecraft.client.MinecraftClient;
 import net.minecraft.client.font.TextRenderer;
 import net.minecraft.client.gui.DrawContext;
 import net.minecraft.entity.player.PlayerEntity;
 import net.minecraft.text.Text;
 
-import java.util.ArrayList;
-import java.util.HashMap;
-import java.util.List;
+import java.util.TreeMap;
 
 /**
  * Handles rendering of penalties, and their hierarchy
@@ -19,13 +18,15 @@ public class PenaltyDisplayManager {
      */
     private static final PenaltyDisplayManager INSTANCE = new PenaltyDisplayManager();
 
-    public static final int HEALTH_PRIORITY = 0;
-    public static final int GLOOM_PRIORITY = 1;
-    public static final int HUNGER_PRIORITY = 2;
+    public static final int HEALTH_PRIORITY = 10;
+    public static final int GLOOM_PRIORITY = 20;
+    public static final int HUNGER_PRIORITY = 30;
+
     /**
      * List of current penalties to be rendered
      */
-    private static HashMap<Integer,Penalty> penalties = new HashMap<>();
+    private static TreeMap<Integer,Penalty> penalties = new TreeMap<>();
+
     /**
      * Indicates if the hunger bar is currently rendered
      */
@@ -51,9 +52,12 @@ public class PenaltyDisplayManager {
         String get();
     }
 
+    /**
+     * Stores information on how and when to draw a penalty
+     */
     static public class Penalty {
         /**
-         * Determines rendering order, with higher values being closer to the hotbar
+         * Determines rendering order, with lower values being closer to the hotbar
          */
         protected int priority;
         /**
@@ -65,36 +69,59 @@ public class PenaltyDisplayManager {
          */
         protected PenaltyCondition condition;
 
+        /**
+         * Creates a penalty with variable text and conditions
+         * @param priority Order this penalty will be drawn
+         * @param display Variable text to draw
+         * @param condition Variable condition that must pass for this penalty to draw
+         */
         public Penalty(int priority, PenaltyString display, PenaltyCondition condition) {
             this.priority = priority;
             this.display = display;
             this.condition = condition;
         }
 
+        /**
+         * Creates a penalty with a static string and variable conditions
+         * @param priority Order this penalty will be drawn
+         * @param string Text to draw
+         * @param condition Variable condition that must pass for this penalty to draw
+         */
         public Penalty(int priority, String string, PenaltyCondition condition) {
             this.priority = priority;
             this.display = () -> string;
             this.condition = condition;
         }
 
+        /**
+         * Creates a penalty with a variable string that will always draw
+         * @param priority Order this penalty will be drawn
+         * @param display Variable text to draw
+         */
         public Penalty(int priority, PenaltyString display) {
             this.priority = priority;
             this.display = display;
             this.condition = () -> true;
         }
 
+        /**
+         * Gets the priority level for this penalty
+         */
         public int getPriority() {
             return this.priority;
         }
 
+        /**
+         * Gets current displayed text for this penalty
+         */
         public String getDisplay() {
             return this.display.get();
         }
     }
 
-    public static void render(DrawContext context, TextRenderer renderer) {
+    public void render(DrawContext context, TextRenderer renderer) {
         PlayerEntity player = MinecraftClient.getInstance().player;
-        renderPenalties(context, renderer, player);
+        this.renderPenalties(context, renderer, player);
     }
 
     /**
@@ -103,13 +130,13 @@ public class PenaltyDisplayManager {
      * @param renderer TextRenderer to use for drawing text
      * @param player PlayerEntity to get information from
      */
-    private static void renderPenalties(DrawContext context, TextRenderer renderer, PlayerEntity player) {
+    private void renderPenalties(DrawContext context, TextRenderer renderer, PlayerEntity player) {
         // Calculate the position of the hunger bar
         int hungerBarX = context.getScaledWindowWidth() / 2 + 91;  // Center of the hunger bar
         int hungerBarY = context.getScaledWindowHeight() - 39; // Hunger bar position vertically
 
         // Get y position to start drawing penalties
-        int textY = getTextY(player, hungerBarY);
+        int textY = this.getTextY(player, hungerBarY);
         int offsetY = 0;
 
         for (Penalty penalty : penalties.values()) {
@@ -120,7 +147,7 @@ public class PenaltyDisplayManager {
             int statusX = hungerBarX - renderer.getWidth(translatedText);
 
             // Render
-            if (penalty.condition.test() && !translatedText.equals(Text.of(""))) {
+            if (penalty.condition.test() && !translatedText.getString().isEmpty()) {
                 context.drawText(renderer, translatedText, statusX, textY - offsetY, 0xFFFFFFFF, true);
                 offsetY += 10;
             }
@@ -136,7 +163,7 @@ public class PenaltyDisplayManager {
      * @param hungerBarY Y position of the hunger bar
      * @return Calculated Y position
      */
-    private static int getTextY(PlayerEntity player, int hungerBarY) {
+    private int getTextY(PlayerEntity player, int hungerBarY) {
         // Get additional context
         boolean isRenderingAir = player.getAir() != player.getMaxAir();
         boolean isRenderingArmor = player.getArmor() > 0;
@@ -156,12 +183,47 @@ public class PenaltyDisplayManager {
         return textY;
     }
 
-    public static void setRenderingFood(boolean value) {
+    /**
+     * Sets indicator for whether food bar is rendering or not
+     */
+    public void setRenderingFood(boolean value) {
         isRenderingFood = value;
     }
 
-    public void addPenalty(Penalty penalty) {
-        int index = penalty.getPriority();
-        penalties.put(index, penalty);
+    /**
+     * Adds penalty to TreeMap
+     * @param newPenalty Penalty to add
+     */
+    public void addPenalty(Penalty newPenalty) {
+        // Get index and verify another key doesn't exist
+        int index = newPenalty.getPriority();
+        boolean hasKey = penalties.containsKey(index);
+
+        // If a key exists, continue bumping index until we reach an open key
+        while (hasKey) {
+            hasKey = penalties.containsKey(++index);
+        }
+        penalties.put(index, newPenalty);
+    }
+
+    /**
+     * Removes penalty from TreeMap
+     * @param newPenalty Penalty to remove
+     */
+    public void removePenalty(Penalty newPenalty) {
+        int index = newPenalty.getPriority();
+        removePenaltyAtIndex(index);
+    }
+
+    /**
+     * Removes penalty at index from TreeMap
+     * @param index Index to attempt removal at
+     */
+    public void removePenaltyAtIndex(int index) {
+        try {
+            penalties.remove(index);
+        } catch (IndexOutOfBoundsException e) {
+            BTWRSLMod.LOGGER.error("Could not remove penalty!", e.getCause());
+        }
     }
 }

--- a/src/client/java/btwr/btwr_sl/lib/mixin/InGameHudMixin.java
+++ b/src/client/java/btwr/btwr_sl/lib/mixin/InGameHudMixin.java
@@ -1,0 +1,38 @@
+package btwr.btwr_sl.lib.mixin;
+
+import btwr.btwr_sl.lib.gui.PenaltyDisplayManager;
+import net.minecraft.client.font.TextRenderer;
+import net.minecraft.client.gui.DrawContext;
+import net.minecraft.client.gui.hud.InGameHud;
+import net.minecraft.entity.player.PlayerEntity;
+import org.spongepowered.asm.mixin.Mixin;
+import org.spongepowered.asm.mixin.Shadow;
+import org.spongepowered.asm.mixin.injection.At;
+import org.spongepowered.asm.mixin.injection.Inject;
+import org.spongepowered.asm.mixin.injection.callback.CallbackInfo;
+
+@Mixin(InGameHud.class)
+public abstract class InGameHudMixin {
+    @Shadow
+    public abstract TextRenderer getTextRenderer();
+
+    /**
+     * Checks to see if renderFood was called and not intercepted,
+     * indicating that hunger has been successfully rendered
+     */
+    @Inject(method = "renderFood", at = @At("TAIL"))
+    private void renderFoodCheck(DrawContext context, PlayerEntity player, int top, int right, CallbackInfo ci) {
+        PenaltyDisplayManager.setRenderingFood(true);
+    }
+
+    /**
+     * Injects penalty status rendering into the vanilla status bar renderer
+     */
+    @Inject(method = "renderStatusBars", at = @At("HEAD"))
+    private void injectedRender(DrawContext context, CallbackInfo ci) {
+        TextRenderer renderer = getTextRenderer();
+        PenaltyDisplayManager.render(context, renderer);
+    }
+
+
+}

--- a/src/client/java/btwr/btwr_sl/lib/mixin/InGameHudMixin.java
+++ b/src/client/java/btwr/btwr_sl/lib/mixin/InGameHudMixin.java
@@ -1,10 +1,13 @@
 package btwr.btwr_sl.lib.mixin;
 
+import btwr.btwr_sl.lib.event.EventHUDInitialized;
 import btwr.btwr_sl.lib.gui.PenaltyDisplayManager;
+import net.minecraft.client.MinecraftClient;
 import net.minecraft.client.font.TextRenderer;
 import net.minecraft.client.gui.DrawContext;
 import net.minecraft.client.gui.hud.InGameHud;
 import net.minecraft.entity.player.PlayerEntity;
+import org.spongepowered.asm.mixin.Final;
 import org.spongepowered.asm.mixin.Mixin;
 import org.spongepowered.asm.mixin.Shadow;
 import org.spongepowered.asm.mixin.injection.At;
@@ -22,7 +25,8 @@ public abstract class InGameHudMixin {
      */
     @Inject(method = "renderFood", at = @At("TAIL"))
     private void renderFoodCheck(DrawContext context, PlayerEntity player, int top, int right, CallbackInfo ci) {
-        PenaltyDisplayManager.setRenderingFood(true);
+        PenaltyDisplayManager dm = PenaltyDisplayManager.getInstance();
+        dm.setRenderingFood(true);
     }
 
     /**
@@ -31,8 +35,17 @@ public abstract class InGameHudMixin {
     @Inject(method = "renderStatusBars", at = @At("HEAD"))
     private void injectedRender(DrawContext context, CallbackInfo ci) {
         TextRenderer renderer = getTextRenderer();
-        PenaltyDisplayManager.render(context, renderer);
+        PenaltyDisplayManager dm = PenaltyDisplayManager.getInstance();
+
+        dm.render(context, renderer);
     }
 
+    /**
+     * Sends out event for other mods to register their penalties
+     */
+    @Inject(method = "<init>", at = @At("TAIL"))
+    private void sendEvent(MinecraftClient client, CallbackInfo ci) {
+        EventHUDInitialized.hudInitialized(client);
+    }
 
 }

--- a/src/client/resources/btwr_sl.client.mixins.json
+++ b/src/client/resources/btwr_sl.client.mixins.json
@@ -4,6 +4,7 @@
   "package": "btwr.btwr_sl.lib.mixin",
   "compatibilityLevel": "JAVA_21",
   "client": [
+    "InGameHudMixin"
   ],
   "injectors": {
     "defaultRequire": 1


### PR DESCRIPTION
This PR's goal is to add in a easy way for mods to register "penalties" to avoid the jank of handling that rendering in BTWR's individual mods. This also allows mods outside of the BTWR ecosystem to display their own penalties! Javadocs are included as well to make sure this system's workings are clear to other developers

How it works is simple:
- Mods that want to use the new system need to extend the `HUDInitializeListener` interface and register it when the client initializes: `EventHUDInitialized.register(listener);` 
- Penalties can be added and removed just by getting the instance of the display manager and calling `addPenalty(penalty)` / `removePenalty(penalty)`
- Penalties take a priority argument, a string condition lambda, and a render condition lambda. This allows precise control over if the penalty is rendered and what the penalty will render without individual mods needing to handle that logic

Once this is merged, PRs will be made for Im'movens and In The Gloom to add BTWRSL as a dependency and alter their rendering logic to use this new system. Attached is an image showing the aforementioned mods using the new system along with a bunch of other (questionable) dummy penalties 😅 

![2025-03-27_10 19 21](https://github.com/user-attachments/assets/2696b9b0-2ff0-4b15-a688-2ac0326e52d0)
