### PR TITLE
Add FOVManager

### DIFF
--- a/src/client/java/btwr/btwr_sl/lib/client/BTWRSLModClient.java
+++ b/src/client/java/btwr/btwr_sl/lib/client/BTWRSLModClient.java
@@ -1,9 +1,6 @@
 package btwr.btwr_sl.lib.client;
 
-import btwr.btwr_sl.lib.gui.PenaltyDisplayManager;
 import net.fabricmc.api.ClientModInitializer;
-import net.minecraft.client.MinecraftClient;
-import net.minecraft.client.Mouse;
 
 public class BTWRSLModClient implements ClientModInitializer
 {

--- a/src/client/java/btwr/btwr_sl/lib/gui/FOVManager.java
+++ b/src/client/java/btwr/btwr_sl/lib/gui/FOVManager.java
@@ -1,0 +1,174 @@
+package btwr.btwr_sl.lib.gui;
+
+
+import com.google.common.collect.Maps;
+import com.google.common.collect.Sets;
+import net.minecraft.entity.attribute.EntityAttributeInstance;
+import net.minecraft.entity.attribute.EntityAttributeModifier;
+import net.minecraft.entity.attribute.EntityAttributes;
+import net.minecraft.entity.player.PlayerEntity;
+
+import java.util.HashMap;
+import java.util.Map;
+import java.util.Set;
+import java.util.function.Function;
+import java.util.stream.Collectors;
+import java.util.stream.Stream;
+
+/**
+ * Intercepts how vanilla handles FOV by removing the values
+ * of attributes from provided namespaces, from the total attribute value.
+ * This is a safe way of reversing the effect of speed penalties on the
+ * client's FOV, and should be compatible with other mods.
+ */
+public class FOVManager {
+    /**
+     * Instance of FOVManager
+     */
+    private static final FOVManager INSTANCE = new FOVManager();
+    /**
+     * List of namespaces to remove attributes from FOV calculations
+     */
+    private static HashMap<String,Namespace> namespaces = new HashMap<>();
+
+    /**
+     * Returns FOVManager instance
+     */
+    public static FOVManager getInstance() {
+        return INSTANCE;
+    }
+
+    /**
+     * Lambda condition test that determines namespace exclusion
+     * from the total speed attribute value
+     */
+    @FunctionalInterface
+    interface ExclusionCondition {
+        boolean test();
+    }
+
+    /**
+     * Represents a mod namespace, and condition in which it's attributes
+     * would be excluded from the total speed attribute value
+     */
+    public class Namespace {
+        private ExclusionCondition condition;
+        private String namespace;
+
+        /**
+         * Constructor that always excludes a given namespace
+         * @param namespace Mod namespace
+         */
+        Namespace(String namespace) {
+            this.condition = () -> true;
+            this.namespace = namespace;
+        }
+
+        /**
+         * Constructor that excludes a given namespace of provided condition passes
+         * @param condition Exclusion condition
+         * @param namespace Mod namespace
+         */
+        Namespace(ExclusionCondition condition, String namespace) {
+            this.condition = condition;
+            this.namespace = namespace;
+        }
+
+        public String getNamespace() {
+            return this.namespace;
+        }
+    }
+
+    /**
+     * Offsets provided speed attribute value based on user configuration.
+     * If there is no attribute instance, it will just return an unmodified attribute value.
+     * @param player PlayerEntity to pull attribute from
+     * @param value Attribute value to offset
+     * @return Modified attribute value, if conditions pass
+     */
+    public double offsetAttribute(PlayerEntity player, double value) {
+        // Get attribute instance
+        EntityAttributeInstance speedAttrib = player.getAttributeInstance(EntityAttributes.GENERIC_MOVEMENT_SPEED);
+        if (speedAttrib != null) {
+            // Get attribute values
+            double baseAttrib = player.getAttributeBaseValue(EntityAttributes.GENERIC_MOVEMENT_SPEED);
+            double filteredAttrib = getAttributeValueFiltered(speedAttrib);
+
+            // Return modified attribute value
+            return value - filteredAttrib + baseAttrib;
+        }
+        return value;
+    }
+
+    /**
+     * Gets the sum of attribute values based on what namespace they're from, and
+     * whether they pass the provided condition defined in the Namespace object
+     * @param attribute Attribute to filter
+     * @return Attribute value with namespaces excluded
+     */
+    public float getAttributeValueFiltered(EntityAttributeInstance attribute) {
+        double baseValue = attribute.getBaseValue();
+
+        Map<EntityAttributeModifier.Operation, Set<EntityAttributeModifier>> operationToModifiers = Stream.of(
+                EntityAttributeModifier.Operation.values()).collect(
+                Collectors.toMap(Function.identity(), operation -> Sets.newHashSet(), (o1, o2) -> o1,
+                        () -> Maps.newEnumMap(EntityAttributeModifier.Operation.class)
+                ));
+
+        // Gets modifiers that are in namespace map and their condition passes
+        attribute.getModifiers()
+                .stream()
+                .filter(this::shouldInclude)
+                .forEach(modifier -> operationToModifiers.get(modifier.operation()).add(modifier));
+
+        // Append all modifiers
+        for (EntityAttributeModifier attributeModifier : operationToModifiers.get(EntityAttributeModifier.Operation.ADD_VALUE)) {
+            baseValue += attributeModifier.value();
+        }
+
+        double baseValueCopy = baseValue;
+
+        for (EntityAttributeModifier attributeModifier : operationToModifiers.get(
+                EntityAttributeModifier.Operation.ADD_MULTIPLIED_BASE)) {
+            baseValueCopy += baseValue * attributeModifier.value();
+        }
+
+        for (EntityAttributeModifier attributeModifier : operationToModifiers.get(
+                EntityAttributeModifier.Operation.ADD_MULTIPLIED_TOTAL)) {
+            baseValueCopy *= 1.0 + attributeModifier.value();
+        }
+
+        return (float) attribute.getAttribute().value().clamp(baseValueCopy);
+    }
+
+    /**
+     * Tests to see if modifier should be filtered (excluded from attribute value)
+     * @param modifier Modifier to test
+     * @return Test result
+     */
+    private boolean shouldInclude(EntityAttributeModifier modifier) {
+        // Get namespace from modifier
+        String namespaceString = modifier.id().getNamespace();
+        Namespace namespace = namespaces.get(namespaceString);
+        if (namespace == null) return false;
+
+        // Return test result
+        return namespace.condition.test();
+    }
+
+    /**
+     * Adds namespace to exclusion list.
+     * @param namespace Namespace object
+     */
+    public void addNamespace(Namespace namespace) {
+        namespaces.put(namespace.getNamespace(), namespace);
+    }
+
+    /**
+     * Adds namespace to exclusion list.
+     * @param namespaceString Mod namespace string
+     */
+    public void addNamespace(String namespaceString) {
+        addNamespace(new Namespace(namespaceString));
+    }
+}

--- a/src/client/java/btwr/btwr_sl/lib/mixin/AbstractClientPlayerEntityMixin.java
+++ b/src/client/java/btwr/btwr_sl/lib/mixin/AbstractClientPlayerEntityMixin.java
@@ -1,0 +1,31 @@
+package btwr.btwr_sl.lib.mixin;
+
+import btwr.btwr_sl.lib.gui.FOVManager;
+import com.llamalad7.mixinextras.injector.ModifyExpressionValue;
+import com.mojang.authlib.GameProfile;
+import net.minecraft.client.network.AbstractClientPlayerEntity;
+import net.minecraft.entity.player.PlayerEntity;
+import net.minecraft.util.math.BlockPos;
+import net.minecraft.world.World;
+import org.spongepowered.asm.mixin.Mixin;
+import org.spongepowered.asm.mixin.injection.At;
+
+@Mixin(value = AbstractClientPlayerEntity.class, priority = 99999)
+public abstract class AbstractClientPlayerEntityMixin extends PlayerEntity {
+    public AbstractClientPlayerEntityMixin(World world, BlockPos pos, float yaw, GameProfile gameProfile) {
+        super(world, pos, yaw, gameProfile);
+    }
+
+    /**
+     * Directly modifies the speed attribute getter to remove modifiers
+     * derived from excluded mod namespaces
+     * @return Attribute value without excluded modifiers
+     */
+    @ModifyExpressionValue(
+            method = "getFovMultiplier",
+            at = @At(value = "INVOKE", target = "Lnet/minecraft/client/network/AbstractClientPlayerEntity;getAttributeValue(Lnet/minecraft/registry/entry/RegistryEntry;)D")
+    )
+    private double modifyAttribValue(double original) {
+        return FOVManager.getInstance().offsetAttribute(this, original);
+    }
+}

--- a/src/client/resources/btwr_sl.client.mixins.json
+++ b/src/client/resources/btwr_sl.client.mixins.json
@@ -4,6 +4,7 @@
   "package": "btwr.btwr_sl.lib.mixin",
   "compatibilityLevel": "JAVA_21",
   "client": [
+    "AbstractClientPlayerEntityMixin",
     "InGameHudMixin"
   ],
   "injectors": {


### PR DESCRIPTION
This PR adds a new class that aids in reverting the effect of speed attributes on FOV calculation. It is an opt-in system similar to that of the PenaltyDisplayManager, where individual mods can add their namespace and a condition and let the FOVManager handle the rest. Setup is straight forward:

- During client initialization, get the FOVManager instance and call `addNamespace` providing either the mod's namespace, or a Namespace object with a lambda condition and the mod's namespace. (e.g. `FOVManager.getInstance().addNamespace("in_the_gloom");`)

...and thats it! It's very simple to use. 

For a technical explanation of the FOVManager class, FOV is mainly determined by the player's speed attribute. The FOVManager holds an exclusion list of mod namespaces, grabs their speed attributes, and reverses individual attribute operations on the total player speed attribute. This means any speed modifiers provided by a given namespace that is in the exclusion list will not affect FOV calculation. 