### PR TITLE
Fix gamebreaking error with CraftingResultSlotMixin

### DIFF
--- a/src/main/java/btwr/btwr_sl/lib/mixin/recipe/CraftingResultSlotMixin.java
+++ b/src/main/java/btwr/btwr_sl/lib/mixin/recipe/CraftingResultSlotMixin.java
@@ -63,7 +63,7 @@ public abstract class CraftingResultSlotMixin {
         if (optional.isPresent() && (craftingRecipe = optional.get().value()) instanceof ShapelessRecipe) {
 
             DefaultedList<ItemStack> drops = ((ShapelessRecipeAdded) craftingRecipe).getAdditionalDrops();
-            if (!drops.isEmpty()) {
+            if (drops != null && !drops.isEmpty()) {
                 for (ItemStack itemStack : drops) {
                     player.dropStack(itemStack.copy());
                 }


### PR DESCRIPTION
BTWRSL introduces new functionality for shapeless recipes, which work as expected within the BTWR ecosystem. An issue arises when a user wants to register a new crafting recipe at runtime with something like Crafttweaker or KubeJS. Upon trying to craft a shapeless recipe, a check for the recipe's additional drops will not go through. That makes sense as that data is provided, but this also somehow leads to players being able to infinitely craft that shapeless recipe without using the ingredients.

You're able to circumvent this by adding an "additionalDrops" field to each recipe definition. However, this solution isn't immediately apparent to most users and would require knowledge that this new field from BWTRSL needs to be accounted for. Of course, this has potential to cause massive issues in modpacks, and may turn some away from wanting to include BTWR components in their pack. I've added an additional check to make sure that the additional drop data exists before running any checks on it

All of this text for such a simple change 😅 I just want to make sure you're aware of reason for it being made